### PR TITLE
Rabina development

### DIFF
--- a/RadiantTune.xcodeproj/project.pbxproj
+++ b/RadiantTune.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		9904EB242C14E3B20069723E /* Lottie.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9904EB232C14E3B20069723E /* Lottie.framework */; };
 		991550A52C13EB4E00DC804A /* RTAnimationUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991550A42C13EB4E00DC804A /* RTAnimationUtility.swift */; };
 		991550A92C144CC200DC804A /* wave.json in Resources */ = {isa = PBXBuildFile; fileRef = 991550A82C144CC200DC804A /* wave.json */; };
+		99C4DAC72C180B4200499DFE /* RTLastPlayedStationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C4DAC62C180B4200499DFE /* RTLastPlayedStationManager.swift */; };
 		AF7952282C1239F90093FE4A /* RTSleepTimerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7952272C1239F90093FE4A /* RTSleepTimerViewController.swift */; };
 		BC1F9DA52C06257B009A074F /* RTAudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1F9DA42C06257B009A074F /* RTAudioPlayer.swift */; };
 		BC1F9DA72C06B456009A074F /* RTPlayingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1F9DA62C06B456009A074F /* RTPlayingViewController.swift */; };
@@ -58,6 +59,7 @@
 		9904EB232C14E3B20069723E /* Lottie.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Lottie.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		991550A42C13EB4E00DC804A /* RTAnimationUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTAnimationUtility.swift; sourceTree = "<group>"; };
 		991550A82C144CC200DC804A /* wave.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = wave.json; sourceTree = "<group>"; };
+		99C4DAC62C180B4200499DFE /* RTLastPlayedStationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTLastPlayedStationManager.swift; sourceTree = "<group>"; };
 		9A002F0EF9CE721E76397281 /* Pods-RadiantTune.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RadiantTune.debug.xcconfig"; path = "Target Support Files/Pods-RadiantTune/Pods-RadiantTune.debug.xcconfig"; sourceTree = "<group>"; };
 		AF7952272C1239F90093FE4A /* RTSleepTimerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTSleepTimerViewController.swift; sourceTree = "<group>"; };
 		BC1F9DA42C06257B009A074F /* RTAudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTAudioPlayer.swift; sourceTree = "<group>"; };
@@ -156,6 +158,15 @@
 				F44D776E46656430F569F95F /* Pods-RadiantTune.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		99C4DAC52C17855300499DFE /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				9904EB232C14E3B20069723E /* Lottie.framework */,
+				C937A0A7AE91CF82920CB983 /* Pods_RadiantTune.framework */,
+			);
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		BC7FE0E72BF26C35005C0B4C /* Home */ = {
@@ -273,6 +284,7 @@
 				BCB5E1372BF039D200C7ADB7 /* Products */,
 				8BF55B6E5A46271A5F4E07FE /* Pods */,
 				C176974EFA5D45500D0A2BB9 /* Frameworks */,
+				99C4DAC52C17855300499DFE /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -320,6 +332,7 @@
 				BC1F9DAA2C06D026009A074F /* RadiantTune-Bridging-Header.h */,
 				991550A42C13EB4E00DC804A /* RTAnimationUtility.swift */,
 				140534282C12571E0082D12D /* RTRadioAPI.swift */,
+				99C4DAC62C180B4200499DFE /* RTLastPlayedStationManager.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -500,6 +513,7 @@
 				BC1F9DA92C06B4BF009A074F /* RTStationModel.swift in Sources */,
 				AF7952282C1239F90093FE4A /* RTSleepTimerViewController.swift in Sources */,
 				FA4042632C0EBA5500B43F72 /* RTFavoriteStationCell.swift in Sources */,
+				99C4DAC72C180B4200499DFE /* RTLastPlayedStationManager.swift in Sources */,
 				BC67D9242C0A179800A4D092 /* RTPlayerWidgetView.swift in Sources */,
 				991550A52C13EB4E00DC804A /* RTAnimationUtility.swift in Sources */,
 			);

--- a/RadiantTune.xcodeproj/xcuserdata/joycelinenathaniel.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/RadiantTune.xcodeproj/xcuserdata/joycelinenathaniel.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -28,7 +28,7 @@
 		<key>RadiantTune.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>5</integer>
+			<integer>10</integer>
 		</dict>
 	</dict>
 </dict>

--- a/RadiantTune/Others/AppDelegate.swift
+++ b/RadiantTune/Others/AppDelegate.swift
@@ -16,6 +16,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         DispatchQueue.global(qos: .userInitiated).async {
             RTDatabaseManager.shared.populateFavoriteUUIDs()
         }
+        
+        
+        playLastPlayedStation()
+        
         return true
     }
 
@@ -33,6 +37,35 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
-
+ 
+    
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        saveCurrentStationState()
+    }
+    
+    func applicationWillTerminate(_ application: UIApplication) {
+        saveCurrentStationState()
+    }
+    
+    private func playLastPlayedStation() {
+        // Load the last played station from UserDefaults
+        if let lastPlayedStation = RTLastPlayedStationManager.loadLastPlayedStation() {
+            // Update the active station and UI state first
+            RTDatabaseManager.shared.activeStation = lastPlayedStation
+            RTPlayerWidgetView.shared.station = lastPlayedStation
+            
+            // Check if auto-play is enabled and start playback if it is
+            if RTLastPlayedStationManager.isAutoPlayEnabled() {
+                RTAudioPlayer.shared.playWith(url: lastPlayedStation.url)
+            }
+        }
+    }
+    
+    private func saveCurrentStationState() {
+        
+        if let station = RTDatabaseManager.shared.activeStation {
+            RTLastPlayedStationManager.saveLastPlayedStation(station)
+        }
+    }
 }
 

--- a/RadiantTune/Utils/RTAudioPlayer.swift
+++ b/RadiantTune/Utils/RTAudioPlayer.swift
@@ -52,10 +52,12 @@ extension RTAudioPlayer: STKAudioPlayerDelegate {
     
     func audioPlayer(_ audioPlayer: STKAudioPlayer, stateChanged state: STKAudioPlayerState, previousState: STKAudioPlayerState) {
         playerState = state
+       
         delegate?.playerStateDidChanged(state: state)
     
         if playerState == .playing {
             NotificationCenter.default.post(name: NSNotification.Name(Constants.FavoritesUpdated), object: nil)
+            NotificationCenter.default.post(name: NSNotification.Name(Constants.StationPlaying), object: nil)
         }
         
         if playerState == .stopped {

--- a/RadiantTune/Utils/RTLastPlayedStationManager.swift
+++ b/RadiantTune/Utils/RTLastPlayedStationManager.swift
@@ -1,0 +1,47 @@
+//
+//  RTLastPlayedStationManager.swift
+//  RadiantTune
+//
+//  Created by Aaribna Gurung on 6/11/24.
+//
+
+import Foundation
+
+
+class RTLastPlayedStationManager {
+    
+    
+    static func setAutoPlayEnabled(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: Constants.AutoPlayEnabled)
+    }
+    
+    static func isAutoPlayEnabled() -> Bool {
+        return UserDefaults.standard.bool(forKey: Constants.AutoPlayEnabled)
+    }
+    
+    static func saveLastPlayedStation(_ station: Station) {
+        let defaults = UserDefaults.standard
+        
+        do {
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(station)
+            defaults.set(data, forKey: Constants.LastPlayedStationKey)
+        } catch {
+            print("Failed to encode station: \(error)")
+        }
+      
+    }
+    
+    static func loadLastPlayedStation() -> Station? {
+        if let data = UserDefaults.standard.data(forKey: Constants.LastPlayedStationKey) {
+            do {
+                let decoder = JSONDecoder()
+                let station = try decoder.decode(Station.self, from: data)
+                return station
+            } catch {
+                print("Failed to decode station: \(error)")
+            }
+        }
+        return nil
+    }
+}

--- a/RadiantTune/Utils/RTUtils.swift
+++ b/RadiantTune/Utils/RTUtils.swift
@@ -12,7 +12,14 @@ struct Constants {
     // MARK: - Reuse identifier for the FavoriteTableViewCell
     static let favoriteTableViewCell = "FavoriteTableViewCell"
     static let FavoritesUpdated = "FavoritesUpdated"
+    
+    static let StationPlaying = "StationPlaying"
     static let StationStopped = "StationStopped"
+
+    
+    // MARK: - Last played station UserDefaults key
+    static let LastPlayedStationKey = "LastPlayedStation"
+    static let AutoPlayEnabled = "AutoPlayEnabled"
 }
 
 
@@ -53,4 +60,24 @@ func setupLottieAnimation(_ animationView: LottieAnimationView, withName name: S
     animationView.contentMode = contentMode
     animationView.loopMode = loopMode
     animationView.animationSpeed = speed
+}
+
+func setupPlayerWidgetConstraints(in viewController: UIViewController, playerWidget: UIView) {
+    playerWidget.translatesAutoresizingMaskIntoConstraints = false
+    viewController.view.addSubview(playerWidget)
+    guard let superview = playerWidget.superview else { return }
+    
+    // Constraints
+    let heightConstraint = playerWidget.heightAnchor.constraint(equalToConstant: 70)
+    let leadingConstraint = playerWidget.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 16)
+    let trailingConstraint = playerWidget.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -16)
+    let bottomConstraint = playerWidget.bottomAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.bottomAnchor)  // Adjusted for safe area
+    
+    // Activate all constraints
+    NSLayoutConstraint.activate([
+        heightConstraint,
+        leadingConstraint,
+        trailingConstraint,
+        bottomConstraint
+    ])
 }

--- a/RadiantTune/Viewcontrollers/Favorite/Controller/RTFavoriteViewController.swift
+++ b/RadiantTune/Viewcontrollers/Favorite/Controller/RTFavoriteViewController.swift
@@ -43,7 +43,7 @@ class RTFavoriteViewController: RTBaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setupPlayerWidgetConstraints()
+        setupPlayerWidgetConstraints(in: self, playerWidget: playerWidget)
         //
         NotificationCenter.default.addObserver(self, selector: #selector(refreshFavorites), name: NSNotification.Name(Constants.FavoritesUpdated), object: nil)
         addLoadingIndicator()
@@ -97,27 +97,6 @@ class RTFavoriteViewController: RTBaseViewController {
         
     }
     
-    func setupPlayerWidgetConstraints() {
-        
-        playerWidget.translatesAutoresizingMaskIntoConstraints = false
-        
-        self.view.addSubview(playerWidget)
-        guard let superview = playerWidget.superview else { return }
-        
-        // Constraints
-        let heightConstraint = playerWidget.heightAnchor.constraint(equalToConstant: 70)
-        let leadingConstraint = playerWidget.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 16)
-        let trailingConstraint = playerWidget.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -16)
-        let bottomConstraint = playerWidget.bottomAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.bottomAnchor)  // Adjusted for safe area
-        
-        // Activate all constraints
-        NSLayoutConstraint.activate([
-            heightConstraint,
-            leadingConstraint,
-            trailingConstraint,
-            bottomConstraint
-        ])
-    }
     
     func addEmptyLabel() {
         

--- a/RadiantTune/Viewcontrollers/Home/Controller/RTHomeViewController.storyboard
+++ b/RadiantTune/Viewcontrollers/Home/Controller/RTHomeViewController.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -39,11 +39,10 @@
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Do5-Ja-RpE" customClass="RTPlayerWidgetView" customModule="RadiantTune" customModuleProvider="target">
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Do5-Ja-RpE" customClass="RTPlayerWidgetView" customModule="RadiantTune" customModuleProvider="target">
                                 <rect key="frame" x="16" y="748" width="361" height="70"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="70" id="NBb-cQ-zlt"/>
-                                </constraints>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ohk-3V-jfo">
                                 <rect key="frame" x="0.0" y="59" width="393" height="50"/>
@@ -68,10 +67,7 @@
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="Do5-Ja-RpE" secondAttribute="trailing" constant="16" id="65R-qN-zcg"/>
                             <constraint firstItem="Ohk-3V-jfo" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="AXM-4l-g2v"/>
-                            <constraint firstItem="Do5-Ja-RpE" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="O4V-ph-cUG"/>
-                            <constraint firstItem="Do5-Ja-RpE" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" id="ZoD-ij-J9R"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="Ohk-3V-jfo" secondAttribute="trailing" id="kwg-tf-9F4"/>
                             <constraint firstItem="Ohk-3V-jfo" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="n57-x9-mbe"/>
                         </constraints>

--- a/RadiantTune/Viewcontrollers/Home/Controller/RTHomeViewController.swift
+++ b/RadiantTune/Viewcontrollers/Home/Controller/RTHomeViewController.swift
@@ -24,6 +24,9 @@ class RTHomeViewController: RTBaseViewController {
         if let station = RTDatabaseManager.shared.activeStation {
             playerWidget.station = station
             playerWidget.refreshState(station: station)
+            playerWidget.isHidden = false
+        } else {
+            playerWidget.isHidden = true
         }
         
     }
@@ -53,8 +56,9 @@ class RTHomeViewController: RTBaseViewController {
         layout.itemSize = CGSize(width: (kScreenWidth - 20)/3, height: (kScreenWidth - 15)/3)
         collectionView.collectionViewLayout = layout
         collectionView.backgroundColor = .white
-        collectionView.contentInset = UIEdgeInsets(top: 60, left: 5, bottom: 0, right: 5)
-        
+        collectionView.contentInset = UIEdgeInsets(top: 60, left: 5, bottom: 150, right: 5)
+       
+        setupPlayerWidgetConstraints(in: self, playerWidget: playerWidget)
         // widget View
         playerWidget.delegate = self
         
@@ -188,9 +192,14 @@ extension RTHomeViewController {
 //MARK:- Search VC Delegate
 extension RTHomeViewController: SearchViewControllerDelegate {
     func rearchControllerDidClosed(station: Station?) {
+        guard let station = station else {
+            print("No station selected")
+            return
+        }
         playerWidget.station = station
         playerWidget.refreshState(station: station)
         RTDatabaseManager.shared.activeStation = station
+        
     }
 }
 

--- a/RadiantTune/Viewcontrollers/Home/View/RTPlayerWidgetView.swift
+++ b/RadiantTune/Viewcontrollers/Home/View/RTPlayerWidgetView.swift
@@ -35,20 +35,26 @@ class RTPlayerWidgetView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()
-        setupAnimationView()
      
-        NotificationCenter.default.addObserver(self, selector: #selector(playerStop), name: NSNotification.Name(Constants.StationStopped), object: nil)
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         commonInit()
-        setupAnimationView()
-        NotificationCenter.default.addObserver(self, selector: #selector(playerStop), name: NSNotification.Name(Constants.StationStopped), object: nil)
- 
-        
-        
     }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    @objc private func playerPlaying() {
+        animationView.play()
+        
+        playButton.setImage(UIImage(systemName: "pause.fill"), for: .normal)
+        playButton.isSelected = true
+    }
+    
+    
     
     @objc private func playerStop() {
         animationView.stop()
@@ -57,9 +63,6 @@ class RTPlayerWidgetView: UIView {
         playButton.isSelected = false
     }
     
-    private func setupAnimationView() {
-        setupLottieAnimation(animationView, withName: "wave")
-    }
     
 
     func commonInit() {
@@ -81,6 +84,12 @@ class RTPlayerWidgetView: UIView {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(iconImageViewAction))
         iconImageView.isUserInteractionEnabled = true
         iconImageView.addGestureRecognizer(tapGesture)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(playerPlaying), name: NSNotification.Name(Constants.StationPlaying), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(playerStop), name: NSNotification.Name(Constants.StationStopped), object: nil)
+        
+        setupLottieAnimation(animationView, withName: "wave")
+        
     }
     
     
@@ -120,6 +129,14 @@ class RTPlayerWidgetView: UIView {
             
             // sub Label
             tagsLabel.text = station.country + "|" + station.tags
+            
+            if (playerState == .playing) {
+                playButton.isSelected = true
+                animationView.play()
+            } else {
+                playButton.isSelected = false
+                animationView.stop()
+            }
         }
     }
     
@@ -141,6 +158,7 @@ class RTPlayerWidgetView: UIView {
             } else {
                 // to play
                 RTAudioPlayer.shared.playWith(url: station.url)
+                saveLastPlayedStation(station)
                 animationView.play()
             }
             sender.isSelected = !sender.isSelected
@@ -180,4 +198,11 @@ class RTPlayerWidgetView: UIView {
         }
     }
     
+    private func saveLastPlayedStation(_ station: Station) {
+        RTLastPlayedStationManager.saveLastPlayedStation(station)
+    }
+    
 }
+
+
+

--- a/RadiantTune/Viewcontrollers/Setting/ViewController/RTSettingViewController.storyboard
+++ b/RadiantTune/Viewcontrollers/Setting/ViewController/RTSettingViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -72,16 +72,46 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="183" translatesAutoresizingMaskIntoConstraints="NO" id="C6S-VM-yfD">
+                                <rect key="frame" x="30" y="242.33333333333337" width="333" height="31"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Auto play" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="092-R5-p9F">
+                                        <rect key="frame" x="0.0" y="0.0" width="101" height="24"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="D1I-IT-YaZ" userLabel="Auto Play Switch">
+                                        <rect key="frame" x="284" y="0.0" width="51" height="31"/>
+                                        <connections>
+                                            <action selector="onAutoPlaySwitchChanged:" destination="Y6W-OH-hqX" eventType="valueChanged" id="0tv-6L-1vn"/>
+                                        </connections>
+                                    </switch>
+                                </subviews>
+                            </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable auto-play to automatically start the radio station when the app is opened." textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EuV-4f-Qf7">
+                                <rect key="frame" x="30" y="281.33333333333331" width="280" height="57.333333333333314"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="C6S-VM-yfD" secondAttribute="trailing" constant="30" id="79W-MA-3HA"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="EuV-4f-Qf7" secondAttribute="trailing" constant="83" id="7OQ-q5-Bvd"/>
                             <constraint firstItem="ZhD-nm-H9L" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="8Gg-wi-Zd9"/>
                             <constraint firstAttribute="trailing" secondItem="ZhD-nm-H9L" secondAttribute="trailing" constant="30" id="Doh-kv-K5Y"/>
                             <constraint firstItem="ZhD-nm-H9L" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="30" id="KUF-YO-6S7"/>
+                            <constraint firstItem="C6S-VM-yfD" firstAttribute="top" secondItem="ZhD-nm-H9L" secondAttribute="bottom" constant="24" id="ZWV-4d-Wcx"/>
+                            <constraint firstItem="EuV-4f-Qf7" firstAttribute="top" secondItem="C6S-VM-yfD" secondAttribute="bottom" constant="8" id="iHq-uP-u2x"/>
+                            <constraint firstItem="C6S-VM-yfD" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="j5d-6F-aao"/>
+                            <constraint firstItem="EuV-4f-Qf7" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="uP6-kL-bUc"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="autoPlaySwitch" destination="D1I-IT-YaZ" id="Abf-AJ-vIU"/>
                         <outlet property="playerWidgetView" destination="BqE-eL-W9q" id="CX3-fS-f1r"/>
                         <outlet property="setTimerBtn" destination="10Z-QM-qqO" id="L4J-AN-Kd4"/>
                         <outlet property="sleepTimerSwitch" destination="khe-r0-lEA" id="fPE-hr-A0B"/>

--- a/RadiantTune/Viewcontrollers/Setting/ViewController/RTSettingViewController.swift
+++ b/RadiantTune/Viewcontrollers/Setting/ViewController/RTSettingViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class RTSettingViewController: RTBaseViewController, RTSleepTimerDelegate {
     
+    @IBOutlet weak var  autoPlaySwitch: UISwitch!
     @IBOutlet weak var playerWidgetView: RTPlayerWidgetView!
     @IBOutlet weak var sleepTimerSwitch: UISwitch!
     @IBOutlet weak var setTimerBtn: UIButton!
@@ -21,21 +22,13 @@ class RTSettingViewController: RTBaseViewController, RTSleepTimerDelegate {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        if let station = RTDatabaseManager.shared.activeStation {
-            playerWidgetView.station = station
-            playerWidgetView.refreshState(station: station)
-            playerWidgetView.isHidden = false
-        } else {
-            playerWidgetView.isHidden = true
-        }
-        
-        
+        configStation()
+        updateAutoPlaySwitch()
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupPlayerWidgetConstraints()
+        setupPlayerWidgetConstraints(in: self, playerWidget: playerWidgetView)
     
         let switchValue = UserDefaults.standard.bool(forKey: "Switch")
         sleepTimerSwitch.isOn = switchValue
@@ -44,6 +37,21 @@ class RTSettingViewController: RTBaseViewController, RTSleepTimerDelegate {
             setRadioTimer()
         }
         loadSwitchValue()
+    }
+    
+    private func configStation () {
+        if let station = RTDatabaseManager.shared.activeStation {
+            playerWidgetView.station = station
+            playerWidgetView.refreshState(station: station)
+            playerWidgetView.isHidden = false
+        } else {
+            playerWidgetView.isHidden = true
+        }
+        
+    }
+    
+    private func updateAutoPlaySwitch() {
+        autoPlaySwitch.isOn = RTLastPlayedStationManager.isAutoPlayEnabled()
     }
     
     @IBAction func onEditTapped(_ sender: UIButton) {
@@ -63,6 +71,11 @@ class RTSettingViewController: RTBaseViewController, RTSleepTimerDelegate {
             invalidateCurrentTimer()
         }
     }
+    
+    @IBAction func onAutoPlaySwitchChanged(_ sender: UISwitch) {
+        RTLastPlayedStationManager.setAutoPlayEnabled(sender.isOn)
+    }
+    
     
     func setRadioTimer() {
         
@@ -86,33 +99,13 @@ class RTSettingViewController: RTBaseViewController, RTSleepTimerDelegate {
             if(timeLeft == 0) {
                 timer.invalidate()
                 RTAudioPlayer.shared.stop()
+                
+                //Update UI after timer is up
                 RTPlayerWidgetView.shared.refreshState(station: nil)
                 
 
             }
         }
-
-    }
-    private func setupPlayerWidgetConstraints() {
-        
-        playerWidgetView.translatesAutoresizingMaskIntoConstraints = false
-        
-        self.view.addSubview(playerWidgetView)
-        guard let superview = playerWidgetView.superview else { return }
-        
-        // Constraints
-        let heightConstraint = playerWidgetView.heightAnchor.constraint(equalToConstant: 70)
-        let leadingConstraint = playerWidgetView.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 16)
-        let trailingConstraint = playerWidgetView.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -16)
-        let bottomConstraint = playerWidgetView.bottomAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.bottomAnchor)  // Adjusted for safe area
-        
-        // Activate all constraints
-        NSLayoutConstraint.activate([
-            heightConstraint,
-            leadingConstraint,
-            trailingConstraint,
-            bottomConstraint
-        ])
 
     }
     


### PR DESCRIPTION
## Description

This pull request implements the auto-play feature on play start #30. 

Bug fixes https://github.com/Rabinagurung/RadiantTune/issues/30: player widget visibiltiy when no station is selected.
- ensure the player widget is hidden when no station is playing.
- correct the bug causing the player widget to hide when no station is selected from the search bar.

## How To Test:

**Enable Auto-Play:**
- Go to the settings screen.
- Toggle the auto-play switch to 'On'.
- Close and reopen the app. It should start playing the last played station automatically.


**Disable Auto-Play:**
- Go to the settings screen.
- Toggle the auto-play switch to 'Off'.
- Close and reopen the app. It should not start playing the station automatically.

## Reviewer Checklist
- [ ]  Verify the auto-play switch correctly reflects the saved state.
- [ ]  Confirm that enabling auto-play starts the last played station on app launch.
- [ ]  Ensure the last played station is saved correctly when playback starts and when the app closes.
- [ ]  Test the behavior when auto-play is disabled.

## Changes Made
**SettingsViewController:**
- Added a UISwitch to enable or disable auto-play.
- The switch's state is updated based on the saved preference in UserDefaults whenever the settings view appears.
- The state change is handled to save the new preference back to UserDefaults.

**AppDelegate:**
- On app launch, the AppDelegate checks the auto-play setting.
- If auto-play is enabled, the AppDelegate retrieves the last played station from UserDefaults and starts playback using the RTAudioPlayer.

**RTLastPlayedStationManager:**
- This utility class manages the saving and loading of the last played station and auto-play settings.
- Implements methods to save the auto-play state and last played station details into UserDefaults.


